### PR TITLE
mbedTLS submodule update to mbedtls-2.1.18-spwr

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external_libs/mbedTLS"]
 	path = external_libs/mbedTLS
 	url = git@github.com:SunPower/fork_mbedtls.git
-	branch = mbedtls-2.1.6-spwr
+	branch = mbedtls-2.1.18-spwr


### PR DESCRIPTION
Changes upon upstream mbedtls-2.1.18,
  f43007ee9 Merge pull request #1 from SunPower/ra2-3123-mbedtls-upgrade-to-2.1.18-and-disable-ipv6-name-resolution
  6a610b080 consumer need to access mbedtls/config.h
  563c06de8 library/net.c: Only allow IPv4 name resolution
  67b2604e6 streamlined CMakeLists.txt exporting the library ready to be consumed

Signed-off-by: Aníbal Limón <limon.anibal@gmail.com>
